### PR TITLE
fix: add Github workflow ref

### DIFF
--- a/src/instance/instance.service.ts
+++ b/src/instance/instance.service.ts
@@ -105,6 +105,7 @@ export class InstanceService {
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
+          ref: "main",
           inputs: { stack: this.infraStack },
         }),
       },

--- a/test/instances.e2e-spec.ts
+++ b/test/instances.e2e-spec.ts
@@ -150,6 +150,7 @@ describe("Instances (e2e)", () => {
             Authorization: "Bearer test-gh-token",
           }),
           body: JSON.stringify({
+            ref: "main",
             inputs: { stack: "test" },
           }),
         }),


### PR DESCRIPTION
as default branch is not used by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed instance deployment workflow to correctly reference the main branch when triggering deployments via GitHub Actions.
* **Tests**
  * Updated end-to-end test expectations to match the corrected deployment dispatch payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->