### PR TITLE
Use GitHub App for triggering workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,9 +21,12 @@ ADMIN_PASSWORD=
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=development
 
-# GitHub API token for dispatching workflows in `aam-cloud-infrastructure`.
-# Needs the `actions:write` permission.
-GITHUB_API_TOKEN=
+# GitHub App the service authenticates as.
+#
+# ID from [`aam-platform-admin` GitHub App settings page](https://github.com/organizations/Aam-Digital/settings/apps/aam-platform-admin)
+GITHUB_APP_ID=
+# Contents of a `.pem` private key generated on the App settings page
+GITHUB_APP_PRIVATE_KEY=
 
 # Name of Pulumi infrastructure stack of project aam-cloud-instances [1] to deploy when a
 # new instance is created (e.g. staging, production).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,34 @@ For API specs refer to the OpenAPI docs (generated at runtime) available at `/ap
 
 See `.env.example` for environment variables.
 
+### GitHub App Setup
+
+The service authenticates with GitHub as a GitHub App to dispatch workflow runs of
+[`pulumi-up-instances`][] on `Aam-Digital/aam-cloud-infrastructure`.
+
+**Create the App** in the `Aam-Digital` org:
+
+1. Go to **Org Settings → Developer settings → GitHub Apps → New GitHub App**
+2. Set a name (e.g. `aam-platform-admin`) and the homepage URL
+   <https://github.com/Aam-Digital/platform-admin-services>
+3. Uncheck **Active** under Webhooks (not needed)
+4. Under **Repository permissions**, set **Actions: Read and write**
+5. Set **Where can this app be installed** to "Only on this account"
+6. Click **Create GitHub App**
+
+**Install the App** on the target repository:
+
+1. In the App settings, click **Install App**
+2. Install on the `Aam-Digital` org, restrict access to the `aam-cloud-infrastructure` repository
+
+**Configure the service** (see [`.env.example`](.env.example) for all variables):
+
+- `GITHUB_APP_ID`: numeric App ID from the [`aam-platform-admin` settings page](https://github.com/organizations/Aam-Digital/settings/apps/aam-platform-admin)
+- `GITHUB_APP_PRIVATE_KEY`: generate a private key on that page and set it to the `.pem` contents
+
+[pulumi-up-instances]: https://github.com/Aam-Digital/aam-cloud-infrastructure/blob/main/.github/workflows/pulumi-up-instances.yaml
+
+
 ---
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@nestjs/swagger": "^11.4.1",
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.1",
+        "@octokit/auth-app": "^8.2.0",
+        "@octokit/rest": "^22.0.1",
         "@sentry/nestjs": "^10.49.0",
         "@sentry/profiling-node": "^10.49.0",
         "class-transformer": "^0.5.1",
@@ -2377,6 +2379,264 @@
         "npm": ">=5.10.0"
       }
     },
+    "node_modules/@octokit/auth-app": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-8.2.0.tgz",
+      "integrity": "sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-app": "^9.0.3",
+        "@octokit/auth-oauth-user": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "toad-cache": "^3.7.0",
+        "universal-github-app-jwt": "^2.2.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-app": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-9.0.3.tgz",
+      "integrity": "sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.3",
+        "@octokit/auth-oauth-user": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-device": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-8.0.3.tgz",
+      "integrity": "sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-methods": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-oauth-user": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-6.0.2.tgz",
+      "integrity": "sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-oauth-device": "^8.0.3",
+        "@octokit/oauth-methods": "^6.0.2",
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-authorization-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-8.0.0.tgz",
+      "integrity": "sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/oauth-methods": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-6.0.2.tgz",
+      "integrity": "sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/oauth-authorization-url": "^8.0.0",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -4714,6 +4974,12 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/better-sqlite3": {
       "version": "12.9.0",
@@ -8180,6 +8446,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10667,6 +10939,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toad-cache": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.1.tgz",
+      "integrity": "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -11226,6 +11507,18 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
+    },
+    "node_modules/universal-github-app-jwt": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-2.2.2.tgz",
+      "integrity": "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==",
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@nestjs/swagger": "^11.4.1",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.1",
+    "@octokit/auth-app": "^8.2.0",
+    "@octokit/rest": "^22.0.1",
     "@sentry/nestjs": "^10.49.0",
     "@sentry/profiling-node": "^10.49.0",
     "class-transformer": "^0.5.1",
@@ -80,6 +82,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!@octokit|before-after-hook|universal-user-agent|universal-github-app-jwt|is-plain-object|deprecation)"
+    ],
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/src/instance/instance.service.ts
+++ b/src/instance/instance.service.ts
@@ -4,10 +4,13 @@ import {
   ConflictException,
   Injectable,
   Logger,
+  OnModuleInit,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
+import { Octokit } from "@octokit/rest";
+import { createAppAuth } from "@octokit/auth-app";
 import { AvailabilityCheckDto, CreateInstanceDto } from "./dto";
 import { INSTANCE_NAME_PATTERN } from "./dto/create-instance.dto";
 import { Instance } from "./instance.entity";
@@ -29,20 +32,58 @@ const RESERVED_NAMES = new Set([
   "status",
 ]);
 
+const GITHUB_ORG_NAME = "Aam-Digital";
+const GITHUB_INFRA_REPO = "aam-cloud-infrastructure";
+
 @Injectable()
-export class InstanceService {
+export class InstanceService implements OnModuleInit {
   private readonly logger = new Logger(InstanceService.name);
-  private readonly githubApiToken: string | null;
   private readonly infraStack: string;
+  private octokit: Octokit | null = null;
 
   constructor(
     @InjectRepository(Instance)
     private readonly instanceRepo: Repository<Instance>,
     private readonly configService: ConfigService,
   ) {
-    this.githubApiToken =
-      this.configService.get<string>("GITHUB_API_TOKEN") || null;
     this.infraStack = this.configService.getOrThrow<string>("INFRA_STACK");
+  }
+
+  async onModuleInit(): Promise<void> {
+    const appId = this.configService.get<string>("GITHUB_APP_ID");
+    const privateKey = this.configService.get<string>("GITHUB_APP_PRIVATE_KEY");
+
+    if (!appId || !privateKey) {
+      if (this.configService.get<string>("NODE_ENV") !== "development") {
+        throw new Error(
+          "GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY are required in non-development environments",
+        );
+      }
+      this.logger.warn(
+        "GitHub App not configured — workflow dispatch disabled",
+      );
+      return;
+    }
+
+    const appOctokit = new Octokit({
+      authStrategy: createAppAuth,
+      auth: { appId, privateKey: privateKey.replace(/\\n/g, "\n") },
+    });
+
+    const { data: installation } =
+      await appOctokit.rest.apps.getRepoInstallation({
+        owner: GITHUB_ORG_NAME,
+        repo: GITHUB_INFRA_REPO,
+      });
+
+    this.octokit = new Octokit({
+      authStrategy: createAppAuth,
+      auth: {
+        appId,
+        privateKey: privateKey.replace(/\\n/g, "\n"),
+        installationId: installation.id,
+      },
+    });
   }
 
   async findAll(): Promise<Instance[]> {
@@ -88,33 +129,26 @@ export class InstanceService {
   }
 
   private async dispatchInstanceDeployment(): Promise<void> {
-    if (!this.githubApiToken) {
-      this.logger.log("GITHUB_API_TOKEN not set, skipping workflow dispatch");
+    if (!this.octokit) {
+      this.logger.log("Workflow trigger skipped (GitHub App not configured)");
       return;
     }
 
-    // https://github.com/Aam-Digital/aam-cloud-infrastructure/blob/main/.github/workflows/pulumi-up-instances.yaml
-    const workflowFile = "pulumi-up-instances.yaml";
-    const response = await fetch(
-      `https://api.github.com/repos/Aam-Digital/aam-cloud-infrastructure/actions/workflows/${workflowFile}/dispatches`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${this.githubApiToken}`,
-          Accept: "application/vnd.github+json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          ref: "main",
-          inputs: { stack: this.infraStack },
-        }),
-      },
-    );
-
-    if (!response.ok) {
-      const body = await response.text();
-      throw new Error(`GitHub API responded with ${response.status}: ${body}`);
+    try {
+      await this.octokit.rest.actions.createWorkflowDispatch({
+        owner: GITHUB_ORG_NAME,
+        repo: GITHUB_INFRA_REPO,
+        workflow_id: "pulumi-up-instances.yaml",
+        ref: "main",
+        inputs: { stack: this.infraStack },
+      });
+    } catch (e) {
+      throw new Error("Failed to trigger workflow in `pulumi-up-instances", {
+        cause: e,
+      });
     }
+
+    this.logger.log("Triggered pulumi-up workflow");
   }
 
   async checkAvailability(name: string): Promise<AvailabilityCheckDto> {

--- a/src/instance/instance.service.ts
+++ b/src/instance/instance.service.ts
@@ -143,7 +143,7 @@ export class InstanceService implements OnModuleInit {
         inputs: { stack: this.infraStack },
       });
     } catch (e) {
-      throw new Error("Failed to trigger workflow \"pulumi-up-instances.yaml\"", {
+      throw new Error('Failed to trigger workflow "pulumi-up-instances.yaml"', {
         cause: e,
       });
     }

--- a/src/instance/instance.service.ts
+++ b/src/instance/instance.service.ts
@@ -143,12 +143,12 @@ export class InstanceService implements OnModuleInit {
         inputs: { stack: this.infraStack },
       });
     } catch (e) {
-      throw new Error("Failed to trigger workflow in `pulumi-up-instances", {
+      throw new Error("Failed to trigger workflow \"pulumi-up-instances.yaml\"", {
         cause: e,
       });
     }
 
-    this.logger.log("Triggered pulumi-up workflow");
+    this.logger.log("Triggered pulumi-up-instances workflow");
   }
 
   async checkAvailability(name: string): Promise<AvailabilityCheckDto> {

--- a/test/instances.e2e-spec.ts
+++ b/test/instances.e2e-spec.ts
@@ -1,7 +1,10 @@
+jest.mock("@octokit/rest", () => ({ Octokit: jest.fn() }));
+
 import { INestApplication, ValidationPipe } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { Test, TestingModule } from "@nestjs/testing";
 import { TypeOrmModule } from "@nestjs/typeorm";
+import { Octokit } from "@octokit/rest";
 import request from "supertest";
 import { Instance } from "../src/instance/instance.entity";
 import { InstanceModule } from "../src/instance/instance.module";
@@ -49,8 +52,25 @@ const VALID_BREVO_PAYLOAD = {
 
 describe("Instances (e2e)", () => {
   let app: INestApplication;
+  let mockDispatch: jest.Mock;
 
   beforeAll(async () => {
+    mockDispatch = jest.fn().mockResolvedValue({});
+
+    jest.mocked(Octokit).mockImplementation(
+      () =>
+        ({
+          rest: {
+            apps: {
+              getRepoInstallation: jest
+                .fn()
+                .mockResolvedValue({ data: { id: 123 } }),
+            },
+            actions: { createWorkflowDispatch: mockDispatch },
+          },
+        }) as unknown as Octokit,
+    );
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [
         ConfigModule.forRoot({
@@ -62,7 +82,8 @@ describe("Instances (e2e)", () => {
               BREVO_ALLOWED_IPS: "",
               GITHUB_OIDC_AUDIENCE: "test",
               GITHUB_REPOSITORY: "test/test",
-              GITHUB_API_TOKEN: "test-gh-token",
+              GITHUB_APP_ID: "123",
+              GITHUB_APP_PRIVATE_KEY: "fake-key",
               INFRA_STACK: "test",
             }),
           ],
@@ -126,12 +147,8 @@ describe("Instances (e2e)", () => {
   // ────────────────────────────────────────────────────────────────────
 
   describe("POST /api/v1/instances", () => {
-    beforeEach(() => {
-      jest.spyOn(global, "fetch").mockResolvedValue({ ok: true } as Response);
-    });
-
     afterEach(() => {
-      jest.restoreAllMocks();
+      mockDispatch.mockClear();
     });
 
     it("should dispatch the GitHub workflow on instance creation", async () => {
@@ -142,19 +159,13 @@ describe("Instances (e2e)", () => {
 
       await new Promise(setImmediate);
 
-      expect(fetch).toHaveBeenCalledWith(
-        "https://api.github.com/repos/Aam-Digital/aam-cloud-infrastructure/actions/workflows/pulumi-up-instances.yaml/dispatches",
-        expect.objectContaining({
-          method: "POST",
-          headers: expect.objectContaining({
-            Authorization: "Bearer test-gh-token",
-          }),
-          body: JSON.stringify({
-            ref: "main",
-            inputs: { stack: "test" },
-          }),
-        }),
-      );
+      expect(mockDispatch).toHaveBeenCalledWith({
+        owner: "Aam-Digital",
+        repo: "aam-cloud-infrastructure",
+        workflow_id: "pulumi-up-instances.yaml",
+        ref: "main",
+        inputs: { stack: "test" },
+      });
     });
 
     it("should create a new instance", () => {

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -8,5 +8,8 @@
   },
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
-  }
+  },
+  "transformIgnorePatterns": [
+    "node_modules/(?!@octokit|before-after-hook|universal-user-agent|universal-github-app-jwt|is-plain-object|deprecation)"
+  ]
 }


### PR DESCRIPTION
Closes #14

Replace Github Personal Access Token authentication with GitHub App authentication.

Advantages
* Actions are auditable: When a workflow is triggered by the service it shows up  as the Github App/service and not as the user the PAT belongs to
* No need to rotate tokens manually when they expire.
* No need to log into a bot account when a bot account is used
* Permission and access management can be delegated to other users

The PR contains instructions in the README how to setup the App. This is only marginally more involved than creating a fine-grained PAT.

The code is substantially the same complexity.
